### PR TITLE
Set up the HTTP proxy for the failover mode, add testcases, CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,25 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - uses: Gr1N/setup-poetry@v8 #install poetry
+    - name: Install parts of toolchain 
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install requirements with poetry
+      run: poetry install
+    - name: Test with pytest
+      run: |
+        poetry run pytest

--- a/ontologytimemachine/proxy.py
+++ b/ontologytimemachine/proxy.py
@@ -1,20 +1,50 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import threading
+import requests
 
 PORT = 8080
 
 class ProxyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
+        # static usecase to check the Proxy is working
         if 'google.com' in self.path:
             self.send_response(200)
             self.send_header('Content-type', 'text/plain')
             self.end_headers()
             self.wfile.write(b'This is a static response for google.com')
         else:
-            self.send_response(404)
-            self.send_header('Content-type', 'text/plain')
-            self.end_headers()
-            self.wfile.write(b'Resource not found')
+            print(self.path)
+            ontology = self.path[1:]
+            print(ontology)
+            try:
+                response = requests.get(ontology)
+                content_type = response.headers.get('Content-Type', '')
+
+                if response.status_code == 200 and content_type in ['text/turtle']:
+                    self.send_response(200)
+                    self.send_header('Content-type', content_type)
+                    self.end_headers()
+                    self.wfile.write(response.content)
+                else:
+                    self.fetch_from_dbpedia_archivo_api(ontology)
+
+            except requests.exceptions.RequestException:
+                self.fetch_from_dbpedia_archivo_api(ontology)
+
+    def fetch_from_dbpedia_archivo_api(self, ontology):
+        dbpedia_url = f'https://archivo.dbpedia.org/download?o={ontology}&f=ttl'
+        print(dbpedia_url)
+        try:
+            response = requests.get(dbpedia_url)
+            if response.status_code == 200:
+                self.send_response(200)
+                self.send_header('Content-type', 'text/turtle')
+                self.end_headers()
+                self.wfile.write(response.content)
+            else:
+                self.send_error(404, 'Resource not found')
+        except requests.exceptions.RequestException:
+            self.send_error(404, 'Resource not found')
 
 def run_proxy(server_class=HTTPServer, handler_class=ProxyHandler, port=PORT):
     server_address = ('', port)

--- a/ontologytimemachine/proxy.py
+++ b/ontologytimemachine/proxy.py
@@ -1,0 +1,32 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+
+PORT = 8080
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if 'google.com' in self.path:
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'This is a static response for google.com')
+        else:
+            self.send_response(404)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'Resource not found')
+
+def run_proxy(server_class=HTTPServer, handler_class=ProxyHandler, port=PORT):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print(f'Starting proxy on port {port}...')
+    httpd.serve_forever()
+
+def start_proxy():
+    proxy_thread = threading.Thread(target=run_proxy)
+    proxy_thread.daemon = True
+    proxy_thread.start()
+    return proxy_thread
+
+if __name__ == '__main__':
+    start_proxy().join()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "ontologytimemachine"
+version = "0.1.0"
+description = ""
+authors = ["Jenifer Tabita Ciuciu-Kiss <jenifer.tabita.ciuciu.kiss@gmail.com>"]
+readme = "README.md"
+packages = [{include = "ontologytimemachine"}]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+pytest = "^8.2.1"
+requests = "^2.32.3"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/proxy_tests.py
+++ b/tests/proxy_tests.py
@@ -1,0 +1,26 @@
+import pytest
+import requests
+from ontologytimemachine.proxy import start_proxy, PORT
+
+PROXY_URL = f'http://localhost:{PORT}'
+
+@pytest.fixture(scope="module", autouse=True)
+def start_proxy_server():
+    start_proxy()
+    import time
+    time.sleep(1)
+
+def test_google_com():
+    response = requests.get(PROXY_URL + '/google.com')
+    assert response.status_code == 200
+    print(response.text)
+    assert response.text == 'This is a static response for google.com'
+
+def test_other_site():
+    response = requests.get(PROXY_URL + '/example.com')
+    assert response.status_code == 404
+    print(response.text)
+    assert response.text == 'Resource not found'
+
+if __name__ == '__main__':
+    pytest.main(["-v", __file__])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -23,4 +23,4 @@ def test_other_site():
     assert response.text == 'Resource not found'
 
 if __name__ == '__main__':
-    pytest.main(["-v", __file__])
+    pytest.main()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -13,14 +13,18 @@ def start_proxy_server():
 def test_google_com():
     response = requests.get(PROXY_URL + '/google.com')
     assert response.status_code == 200
-    print(response.text)
     assert response.text == 'This is a static response for google.com'
 
-def test_other_site():
-    response = requests.get(PROXY_URL + '/example.com')
-    assert response.status_code == 404
-    print(response.text)
-    assert response.text == 'Resource not found'
+def test_linked_web_apis():
+    response = requests.get(PROXY_URL + '/http://linked-web-apis.fit.cvut.cz/ns/core')
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'text/turtle'
+
+def test_ontologi_es():
+    response = requests.get(PROXY_URL + '/http%3A//ontologi.es/days%23')
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'text/turtle'
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
- Set up the project
- Create poetry venv
- Set up the HTTP proxy
- Implement the failover mode
- Add testcases
- Add GitHub action for running the tests

Logic of the failover mode:
- If the ontology return returns a 200 and a 'text/turtle' content type it returns the original response
- It calls the archive API otherwise

Limitations:
- Only works for ttl, has to be extended to owl and nt